### PR TITLE
Validation Checks + UI Framework

### DIFF
--- a/src/components/inputs/Inputs.jsx
+++ b/src/components/inputs/Inputs.jsx
@@ -2102,7 +2102,8 @@ const ReferenceTable = observer(({
   width="Wide",
   AddItem,
   CopyItem,
-  Actions
+  Actions,
+  OnDelete
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -2232,14 +2233,20 @@ const ReferenceTable = observer(({
                           ConfirmDelete({
                             itemName: itemName,
                             onConfirm: () => {
-                              store.RemoveField({
+                              store.ApplyTransaction( {
                                 objectId,
-                                page,
-                                path: UrlJoin(path, field),
-                                field: item.id,
-                                category,
-                                subcategory,
-                                label: itemName
+                                Apply: () => {
+                                  store.RemoveField({
+                                    objectId,
+                                    page,
+                                    path: UrlJoin(path, field),
+                                    field: item.id,
+                                    category,
+                                    subcategory,
+                                    label: itemName
+                                  });
+                                  OnDelete?.(item);
+                                }
                               });
                             }
                           });

--- a/src/components/inputs/Inputs.jsx
+++ b/src/components/inputs/Inputs.jsx
@@ -2235,6 +2235,12 @@ const ReferenceTable = observer(({
                             onConfirm: () => {
                               store.ApplyTransaction( {
                                 objectId,
+                                page,
+                                path: UrlJoin(path, field),
+                                field: item.id,
+                                category,
+                                subcategory,
+                                label: itemName,
                                 Apply: () => {
                                   store.RemoveField({
                                     objectId,

--- a/src/pages/media_properties/MediaPropertySections.jsx
+++ b/src/pages/media_properties/MediaPropertySections.jsx
@@ -137,6 +137,7 @@ export const MediaPropertySectionsTable = observer(({
           });
         });
       }}
+      OnDelete={(item) => mediaPropertyStore.RemoveSection(mediaPropertyId, item.id)}
       columns={[
         {
           accessor: "label",

--- a/src/stores/MediaPropertyStore.js
+++ b/src/stores/MediaPropertyStore.js
@@ -27,7 +27,6 @@ import {LocalizeString} from "@/components/common/Misc.jsx";
 import {Slugify} from "@/components/common/Validation.jsx";
 
 import {Migrations, latestVersion} from "@/migrations/MediaPropertyMigrations.js";
-import {mediaCatalogStore, marketplaceStore, permissionSetStore, mediaPropertyStore} from "@/stores/index.js";
 
 class MediaPropertyStore {
   allMediaProperties;
@@ -640,7 +639,7 @@ class MediaPropertyStore {
       for(let i = sections.length - 1; i >= 0 ; i--) {
         if (sections[i] === sectionId) {
           // Remove section each time it is referenced by the page
-          mediaPropertyStore.RemoveListElement({
+          this.rootStore.mediaPropertyStore.RemoveListElement({
             objectId: mediaPropertyId,
             page: UrlJoin("media-properties", mediaPropertyId, "pages", pageId),
             path: UrlJoin("/public/asset_metadata/info/pages", pageId, "layout"),
@@ -716,13 +715,13 @@ class MediaPropertyStore {
     const info = mediaProperty?.metadata?.public?.asset_metadata?.info || {};
 
     // Load media catalogs, marketplaces, and permission sets via database
-    yield mediaCatalogStore.LoadMediaCatalogs();
-    yield marketplaceStore.LoadMarketplaces();
-    yield permissionSetStore.LoadPermissionSets();
+    yield this.rootStore.mediaCatalogStore.LoadMediaCatalogs();
+    yield this.rootStore.marketplaceStore.LoadMarketplaces();
+    yield this.rootStore.permissionSetStore.LoadPermissionSets();
 
     // Media Catalogs
     info.media_catalogs?.forEach(catalogId => {
-      if (!(catalogId in mediaCatalogStore.allMediaCatalogs)) {
+      if (!this.rootStore.mediaCatalogStore.allMediaCatalogs.find(catalog => catalog.objectId === catalogId)) {
         missing.push({
           type: "Error",
           message: "Missing/invalid media catalog: " + catalogId,
@@ -733,7 +732,7 @@ class MediaPropertyStore {
 
     // Marketplaces
     info.associated_marketplaces?.forEach(marketplace => {
-      if (!(marketplace.marketplace_id in marketplaceStore.allMarketplaces)) {
+      if (!this.rootStore.marketplaceStore.allMarketplaces.find(marketplace2 => marketplace2.objectId === marketplace.marketplace_id)) {
         missing.push({
           type: "Error",
           message: "Missing/invalid marketplace: " + marketplace.marketplace_id,
@@ -744,7 +743,7 @@ class MediaPropertyStore {
 
     // Permission Sets
     info.permission_sets?.forEach(permissionSetId => {
-      if (!(permissionSetId in permissionSetStore.allPermissionSets)) {
+      if (!this.rootStore.permissionSetStore.allPermissionSets.find(permissionSet => permissionSet.objectId === permissionSetId)) {
         missing.push({
           type: "Error",
           message: "Missing/invalid permission set: " + permissionSetId,

--- a/src/stores/PermissionSetStore.js
+++ b/src/stores/PermissionSetStore.js
@@ -146,9 +146,10 @@ class PermissionSetStore {
     };
   }
 
-  ValidatePermissionItemLinks = permissionSetId => {
+  ValidatePermissionItemLinks = flow(function * (permissionSetId) {
     // Detect missing marketplaces that are linked from permission items
     const missingMarketplaces = [];
+    yield this.LoadPermissionSet({permissionSetId});
     const permissionSet = this.permissionSets[permissionSetId];
     const info = permissionSet?.metadata?.public?.asset_metadata?.info || {};
 
@@ -164,7 +165,7 @@ class PermissionSetStore {
       }
     }
     return missingMarketplaces;
-  };
+  });
 
   Reload = flow(function * ({objectId}) {
     yield this.LoadPermissionSet({permissionSetId: objectId, force: true});

--- a/src/stores/PermissionSetStore.js
+++ b/src/stores/PermissionSetStore.js
@@ -5,7 +5,6 @@ import {GenerateUUID} from "@/helpers/Misc.js";
 import UrlJoin from "url-join";
 import {LocalizeString} from "@/components/common/Misc.jsx";
 import {PermissionItemOwnedSpec, PermissionSetSpec} from "@/specs/PermissionSetSpecs.js";
-import {marketplaceStore} from "@/stores/index.js";
 
 class PermissionSetStore {
   allPermissionSets;
@@ -155,10 +154,10 @@ class PermissionSetStore {
 
     for (const permissionItemId in info.permission_items) {
       const permissionItem = info.permission_items[permissionItemId];
-      const marketplace = marketplaceStore.allMarketplaces.find(marketplace => marketplace.objectId === permissionItem.marketplace.marketplace_id);
+      const marketplace = this.rootStore.marketplaceStore.allMarketplaces.find(marketplace => marketplace.objectId === permissionItem.marketplace.marketplace_id);
       if (!marketplace) {
         missingMarketplaces.push({
-          type: "error",
+          type: "Error",
           message: "Missing marketplace linked: " + permissionItem.marketplace.marketplace_id,
           link: UrlJoin("permission-sets", permissionSetId, "permission-items", permissionItemId)
         });


### PR DESCRIPTION
**ItemTemplateStore**
- `ValidateTemplateAddresses`: check for missing/invalid contract addresses & contract addresses used by multiple templates

**MediaPropertyStore**
- `RemoveSection`: remove all references the page section from every page in the property (for when page sections are deleted from `MediaPropertySectionsTable`; used by `ApplyTransaction` in `Inputs`)
- `ValidateSections`: check for missing sections referenced by pages
- `ValidateSectionContent`: check for missing media items referenced by media section items, and missing pages referenced by page link section items
- `ValidateGeneral`: check for missing media catalogs, marketplaces, permission sets referenced in general settings

**PermissionSetStore**
- `ValidatePermissionItemLinks`: check for missing marketplaces that are linked from permission items

**SaveModal**
- Added calls to validation functions + showing warnings & errors in accordion item above changes in the Save Modal